### PR TITLE
add ndjson parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "hypercore": "^6.0.0",
     "hyperdiscovery": "^1.1.0",
     "minimist": "^1.2.0",
-    "mkdirp": "^0.5.1"
+    "mkdirp": "^0.5.1",
+    "ndjson": "^1.5.0"
   },
   "devDependencies": {
     "standard": "^8.5.0"


### PR DESCRIPTION
Allows use of hyperpipe to copy existing ndjson files (including other hypercore feeds) into a new feed while preserving each item as an entry.

```
hyperpipe ./feed-db --encoding='json' < my-data.json
```

Or copy an existing `json` encoded hypercore:

```
cat old-feed/data | hyperpipe ./new-feed --encoding='json'
```